### PR TITLE
Fixed the bug for admin privileges

### DIFF
--- a/app/src/main/java/ch/epfl/sweng/studdybuddy/util/GroupsRecyclerAdapter.java
+++ b/app/src/main/java/ch/epfl/sweng/studdybuddy/util/GroupsRecyclerAdapter.java
@@ -132,6 +132,9 @@ public class GroupsRecyclerAdapter extends RecyclerView.Adapter<GroupsRecyclerAd
         if(userId.equals(group.getAdminID())) {
             holder.admin.setText("\uD83D\uDC51");
         }
+        else {
+            holder.admin.setText("");
+        }
     }
 
     @Override


### PR DESCRIPTION
This is a one-liner fix to the issue we had with admin privileges appearing to be given to random groups after sorting or filtering