### PR TITLE
[BUG] fix the app crash on group deletion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ before_script:
   - chmod +x ./cc-test-reporter
   - ./cc-test-reporter before-build
 script:
+  - chmod +x ./gradlew
   - travis_wait 45 ./gradlew build connectedCheck jacocoTestReport
 after_script:
   # Report test coverage to Code Climate

--- a/app/src/androidTest/java/ch/epfl/sweng/studdybuddy/AdapterTest.java
+++ b/app/src/androidTest/java/ch/epfl/sweng/studdybuddy/AdapterTest.java
@@ -12,8 +12,8 @@ import org.junit.runner.RunWith;
 import java.util.ArrayList;
 
 import ch.epfl.sweng.studdybuddy.activities.GroupInfoActivity;
-import ch.epfl.sweng.studdybuddy.util.Adapter;
-import ch.epfl.sweng.studdybuddy.util.ParticipantAdapter;
+import ch.epfl.sweng.studdybuddy.tools.Adapter;
+import ch.epfl.sweng.studdybuddy.tools.ParticipantAdapter;
 
 import static junit.framework.TestCase.assertTrue;
 

--- a/app/src/main/java/ch/epfl/sweng/studdybuddy/Fragments/FeedFragment.java
+++ b/app/src/main/java/ch/epfl/sweng/studdybuddy/Fragments/FeedFragment.java
@@ -25,13 +25,12 @@ import java.util.List;
 
 import ch.epfl.sweng.studdybuddy.R;
 import ch.epfl.sweng.studdybuddy.activities.CreateGroupActivity;
-import ch.epfl.sweng.studdybuddy.activities.GroupsActivity;
 import ch.epfl.sweng.studdybuddy.core.Group;
 import ch.epfl.sweng.studdybuddy.firebase.FirebaseReference;
-import ch.epfl.sweng.studdybuddy.util.AdapterConsumer;
-import ch.epfl.sweng.studdybuddy.util.Consumer;
-import ch.epfl.sweng.studdybuddy.util.GroupsRecyclerAdapter;
-import ch.epfl.sweng.studdybuddy.util.RecyclerAdapterAdapter;
+import ch.epfl.sweng.studdybuddy.tools.AdapterConsumer;
+import ch.epfl.sweng.studdybuddy.tools.Consumer;
+import ch.epfl.sweng.studdybuddy.tools.GroupsRecyclerAdapter;
+import ch.epfl.sweng.studdybuddy.tools.RecyclerAdapterAdapter;
 import ch.epfl.sweng.studdybuddy.util.StudyBuddy;
 
 /**

--- a/app/src/main/java/ch/epfl/sweng/studdybuddy/Fragments/ProfileFragment.java
+++ b/app/src/main/java/ch/epfl/sweng/studdybuddy/Fragments/ProfileFragment.java
@@ -21,9 +21,9 @@ import ch.epfl.sweng.studdybuddy.core.User;
 import ch.epfl.sweng.studdybuddy.firebase.FirebaseReference;
 import ch.epfl.sweng.studdybuddy.firebase.MetaGroup;
 import ch.epfl.sweng.studdybuddy.firebase.ReferenceWrapper;
-import ch.epfl.sweng.studdybuddy.util.CourseAdapter;
-import ch.epfl.sweng.studdybuddy.util.GroupsRecyclerAdapter;
-import ch.epfl.sweng.studdybuddy.util.RecyclerAdapterAdapter;
+import ch.epfl.sweng.studdybuddy.tools.CourseAdapter;
+import ch.epfl.sweng.studdybuddy.tools.GroupsRecyclerAdapter;
+import ch.epfl.sweng.studdybuddy.tools.RecyclerAdapterAdapter;
 import ch.epfl.sweng.studdybuddy.util.StudyBuddy;
 
 /**

--- a/app/src/main/java/ch/epfl/sweng/studdybuddy/activities/ConnectedCalendarActivity.java
+++ b/app/src/main/java/ch/epfl/sweng/studdybuddy/activities/ConnectedCalendarActivity.java
@@ -32,7 +32,7 @@ import ch.epfl.sweng.studdybuddy.services.calendar.Availability;
 import ch.epfl.sweng.studdybuddy.services.calendar.ConcreteAvailability;
 import ch.epfl.sweng.studdybuddy.services.calendar.ConnectedAvailability;
 import ch.epfl.sweng.studdybuddy.services.calendar.ConnectedCalendar;
-import ch.epfl.sweng.studdybuddy.util.Consumer;
+import ch.epfl.sweng.studdybuddy.tools.Consumer;
 import ch.epfl.sweng.studdybuddy.util.Messages;
 
 /**

--- a/app/src/main/java/ch/epfl/sweng/studdybuddy/activities/CourseSelectActivity.java
+++ b/app/src/main/java/ch/epfl/sweng/studdybuddy/activities/CourseSelectActivity.java
@@ -27,11 +27,11 @@ import ch.epfl.sweng.studdybuddy.core.Pair;
 import ch.epfl.sweng.studdybuddy.core.User;
 import ch.epfl.sweng.studdybuddy.firebase.FirebaseReference;
 import ch.epfl.sweng.studdybuddy.firebase.ReferenceWrapper;
-import ch.epfl.sweng.studdybuddy.util.AdapterConsumer;
-import ch.epfl.sweng.studdybuddy.util.ArrayAdapterAdapter;
-import ch.epfl.sweng.studdybuddy.util.CourseAdapter;
+import ch.epfl.sweng.studdybuddy.tools.AdapterConsumer;
+import ch.epfl.sweng.studdybuddy.tools.ArrayAdapterAdapter;
+import ch.epfl.sweng.studdybuddy.tools.CourseAdapter;
 import ch.epfl.sweng.studdybuddy.util.Helper;
-import ch.epfl.sweng.studdybuddy.util.Holder;
+import ch.epfl.sweng.studdybuddy.tools.Holder;
 import ch.epfl.sweng.studdybuddy.util.StudyBuddy;
 
 import static ch.epfl.sweng.studdybuddy.util.ActivityHelper.showDropdown;

--- a/app/src/main/java/ch/epfl/sweng/studdybuddy/activities/CreateGroupActivity.java
+++ b/app/src/main/java/ch/epfl/sweng/studdybuddy/activities/CreateGroupActivity.java
@@ -16,7 +16,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 
-import ch.epfl.sweng.studdybuddy.Fragments.FeedFragment;
 import ch.epfl.sweng.studdybuddy.R;
 import ch.epfl.sweng.studdybuddy.core.Course;
 import ch.epfl.sweng.studdybuddy.core.Group;
@@ -25,8 +24,8 @@ import ch.epfl.sweng.studdybuddy.firebase.FirebaseReference;
 import ch.epfl.sweng.studdybuddy.firebase.MetaGroup;
 import ch.epfl.sweng.studdybuddy.services.calendar.Availability;
 import ch.epfl.sweng.studdybuddy.services.calendar.ConnectedAvailability;
-import ch.epfl.sweng.studdybuddy.util.AdapterConsumer;
-import ch.epfl.sweng.studdybuddy.util.ArrayAdapterAdapter;
+import ch.epfl.sweng.studdybuddy.tools.AdapterConsumer;
+import ch.epfl.sweng.studdybuddy.tools.ArrayAdapterAdapter;
 import ch.epfl.sweng.studdybuddy.util.StudyBuddy;
 
 import static ch.epfl.sweng.studdybuddy.util.ActivityHelper.showDropdown;

--- a/app/src/main/java/ch/epfl/sweng/studdybuddy/activities/GroupInfoActivity.java
+++ b/app/src/main/java/ch/epfl/sweng/studdybuddy/activities/GroupInfoActivity.java
@@ -15,8 +15,8 @@ import ch.epfl.sweng.studdybuddy.R;
 import ch.epfl.sweng.studdybuddy.core.Group;
 import ch.epfl.sweng.studdybuddy.core.User;
 import ch.epfl.sweng.studdybuddy.firebase.MetaGroupAdmin;
-import ch.epfl.sweng.studdybuddy.util.ParticipantAdapter;
-import ch.epfl.sweng.studdybuddy.util.RecyclerAdapterAdapter;
+import ch.epfl.sweng.studdybuddy.tools.ParticipantAdapter;
+import ch.epfl.sweng.studdybuddy.tools.RecyclerAdapterAdapter;
 import ch.epfl.sweng.studdybuddy.util.StudyBuddy;
 
 public class GroupInfoActivity extends AppCompatActivity{
@@ -53,6 +53,7 @@ public class GroupInfoActivity extends AppCompatActivity{
             @Override
             public void onClick(View v) {
                 if (uId != null && gId != null) {
+                    mb.clearListeners();
                     mb.removeUserFromGroup(uId, group.get(0));
                     Intent transition = new Intent(GroupInfoActivity.this, NavigationActivity.class);
                     startActivity(transition);

--- a/app/src/main/java/ch/epfl/sweng/studdybuddy/activities/GroupsActivity.java
+++ b/app/src/main/java/ch/epfl/sweng/studdybuddy/activities/GroupsActivity.java
@@ -1,29 +1,9 @@
 package ch.epfl.sweng.studdybuddy.activities;
 
-import android.content.Intent;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.LinearLayoutManager;
-import android.support.v7.widget.RecyclerView;
-import android.support.v7.widget.SearchView;
-import android.view.View;
-import android.widget.CompoundButton;
-import android.widget.ToggleButton;
-
-import com.google.firebase.database.FirebaseDatabase;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 
 import ch.epfl.sweng.studdybuddy.R;
-import ch.epfl.sweng.studdybuddy.core.Group;
-import ch.epfl.sweng.studdybuddy.firebase.FirebaseReference;
-import ch.epfl.sweng.studdybuddy.util.AdapterConsumer;
-import ch.epfl.sweng.studdybuddy.util.Consumer;
-import ch.epfl.sweng.studdybuddy.util.GroupsRecyclerAdapter;
-import ch.epfl.sweng.studdybuddy.util.RecyclerAdapterAdapter;
-import ch.epfl.sweng.studdybuddy.util.StudyBuddy;
 
 public class GroupsActivity extends AppCompatActivity
 {

--- a/app/src/main/java/ch/epfl/sweng/studdybuddy/activities/ProfileTab.java
+++ b/app/src/main/java/ch/epfl/sweng/studdybuddy/activities/ProfileTab.java
@@ -2,25 +2,8 @@ package ch.epfl.sweng.studdybuddy.activities;
 
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
-import android.support.v7.widget.LinearLayoutManager;
-import android.support.v7.widget.RecyclerView;
-import android.widget.TextView;
-
-import com.google.firebase.database.ValueEventListener;
-
-import java.util.ArrayList;
-import java.util.List;
 
 import ch.epfl.sweng.studdybuddy.R;
-import ch.epfl.sweng.studdybuddy.core.Group;
-import ch.epfl.sweng.studdybuddy.core.User;
-import ch.epfl.sweng.studdybuddy.firebase.FirebaseReference;
-import ch.epfl.sweng.studdybuddy.firebase.MetaGroup;
-import ch.epfl.sweng.studdybuddy.firebase.ReferenceWrapper;
-import ch.epfl.sweng.studdybuddy.util.CourseAdapter;
-import ch.epfl.sweng.studdybuddy.util.GroupsRecyclerAdapter;
-import ch.epfl.sweng.studdybuddy.util.RecyclerAdapterAdapter;
-import ch.epfl.sweng.studdybuddy.util.StudyBuddy;
 
 public class
 ProfileTab extends AppCompatActivity {

--- a/app/src/main/java/ch/epfl/sweng/studdybuddy/auth/GoogleSignInActivity.java
+++ b/app/src/main/java/ch/epfl/sweng/studdybuddy/auth/GoogleSignInActivity.java
@@ -15,14 +15,13 @@ import com.google.firebase.database.ValueEventListener;
 
 import ch.epfl.sweng.studdybuddy.R;
 import ch.epfl.sweng.studdybuddy.activities.CourseSelectActivity;
-import ch.epfl.sweng.studdybuddy.activities.MainActivity;
 import ch.epfl.sweng.studdybuddy.activities.NavigationActivity;
 import ch.epfl.sweng.studdybuddy.core.Account;
 import ch.epfl.sweng.studdybuddy.core.ID;
 import ch.epfl.sweng.studdybuddy.core.User;
 import ch.epfl.sweng.studdybuddy.firebase.FirebaseReference;
 import ch.epfl.sweng.studdybuddy.firebase.ReferenceWrapper;
-import ch.epfl.sweng.studdybuddy.util.Consumer;
+import ch.epfl.sweng.studdybuddy.tools.Consumer;
 import ch.epfl.sweng.studdybuddy.util.StudyBuddy;
 
 public class GoogleSignInActivity extends AppCompatActivity {

--- a/app/src/main/java/ch/epfl/sweng/studdybuddy/firebase/FirebaseReference.java
+++ b/app/src/main/java/ch/epfl/sweng/studdybuddy/firebase/FirebaseReference.java
@@ -13,7 +13,7 @@ import com.google.firebase.database.ValueEventListener;
 import java.util.ArrayList;
 import java.util.List;
 
-import ch.epfl.sweng.studdybuddy.util.Consumer;
+import ch.epfl.sweng.studdybuddy.tools.Consumer;
 
 public class FirebaseReference implements ReferenceWrapper {
     //pass it

--- a/app/src/main/java/ch/epfl/sweng/studdybuddy/firebase/MetaGroup.java
+++ b/app/src/main/java/ch/epfl/sweng/studdybuddy/firebase/MetaGroup.java
@@ -10,8 +10,8 @@ import java.util.Map;
 import ch.epfl.sweng.studdybuddy.core.Group;
 import ch.epfl.sweng.studdybuddy.core.Pair;
 import ch.epfl.sweng.studdybuddy.core.User;
-import ch.epfl.sweng.studdybuddy.util.AdapterAdapter;
-import ch.epfl.sweng.studdybuddy.util.Consumer;
+import ch.epfl.sweng.studdybuddy.tools.AdapterAdapter;
+import ch.epfl.sweng.studdybuddy.tools.Consumer;
 import ch.epfl.sweng.studdybuddy.util.Helper;
 
 import static ch.epfl.sweng.studdybuddy.util.Helper.getOrDefault;

--- a/app/src/main/java/ch/epfl/sweng/studdybuddy/firebase/MetaGroupAdmin.java
+++ b/app/src/main/java/ch/epfl/sweng/studdybuddy/firebase/MetaGroupAdmin.java
@@ -10,7 +10,7 @@ import ch.epfl.sweng.studdybuddy.core.ID;
 import ch.epfl.sweng.studdybuddy.core.Pair;
 import ch.epfl.sweng.studdybuddy.core.User;
 import ch.epfl.sweng.studdybuddy.services.calendar.ConnectedAvailability;
-import ch.epfl.sweng.studdybuddy.util.Consumer;
+import ch.epfl.sweng.studdybuddy.tools.Consumer;
 import ch.epfl.sweng.studdybuddy.util.Helper;
 
 public class MetaGroupAdmin extends MetaGroup {

--- a/app/src/main/java/ch/epfl/sweng/studdybuddy/firebase/Metabase.java
+++ b/app/src/main/java/ch/epfl/sweng/studdybuddy/firebase/Metabase.java
@@ -1,13 +1,15 @@
 package ch.epfl.sweng.studdybuddy.firebase;
 
+import android.support.v7.widget.RecyclerView;
+
 import com.google.firebase.database.ValueEventListener;
 
 import java.util.LinkedList;
 import java.util.List;
 
 import ch.epfl.sweng.studdybuddy.core.User;
-import ch.epfl.sweng.studdybuddy.util.AdapterAdapter;
-import ch.epfl.sweng.studdybuddy.util.Consumer;
+import ch.epfl.sweng.studdybuddy.tools.AdapterAdapter;
+import ch.epfl.sweng.studdybuddy.tools.Consumer;
 
 abstract public class Metabase {
     protected ReferenceWrapper db;
@@ -44,5 +46,7 @@ abstract public class Metabase {
     public void addListenner(AdapterAdapter ad) {
         this.ads.add(ad);
     }
+
+    public void clearListeners() { this.ads.clear(); }
 
 }

--- a/app/src/main/java/ch/epfl/sweng/studdybuddy/firebase/ReferenceWrapper.java
+++ b/app/src/main/java/ch/epfl/sweng/studdybuddy/firebase/ReferenceWrapper.java
@@ -5,7 +5,7 @@ import com.google.firebase.database.ValueEventListener;
 
 import java.util.List;
 
-import ch.epfl.sweng.studdybuddy.util.Consumer;
+import ch.epfl.sweng.studdybuddy.tools.Consumer;
 
 public interface ReferenceWrapper {
     /**

--- a/app/src/main/java/ch/epfl/sweng/studdybuddy/tools/Adapter.java
+++ b/app/src/main/java/ch/epfl/sweng/studdybuddy/tools/Adapter.java
@@ -1,4 +1,4 @@
-package ch.epfl.sweng.studdybuddy.util;
+package ch.epfl.sweng.studdybuddy.tools;
 
 import android.content.Context;
 import android.support.annotation.IdRes;

--- a/app/src/main/java/ch/epfl/sweng/studdybuddy/tools/AdapterAdapter.java
+++ b/app/src/main/java/ch/epfl/sweng/studdybuddy/tools/AdapterAdapter.java
@@ -1,4 +1,4 @@
-package ch.epfl.sweng.studdybuddy.util;
+package ch.epfl.sweng.studdybuddy.tools;
 
 public interface AdapterAdapter {
     void update();

--- a/app/src/main/java/ch/epfl/sweng/studdybuddy/tools/AdapterConsumer.java
+++ b/app/src/main/java/ch/epfl/sweng/studdybuddy/tools/AdapterConsumer.java
@@ -1,4 +1,4 @@
-package ch.epfl.sweng.studdybuddy.util;
+package ch.epfl.sweng.studdybuddy.tools;
 
 import java.util.List;
 

--- a/app/src/main/java/ch/epfl/sweng/studdybuddy/tools/ArrayAdapterAdapter.java
+++ b/app/src/main/java/ch/epfl/sweng/studdybuddy/tools/ArrayAdapterAdapter.java
@@ -1,4 +1,4 @@
-package ch.epfl.sweng.studdybuddy.util;
+package ch.epfl.sweng.studdybuddy.tools;
 
 import android.widget.ArrayAdapter;
 

--- a/app/src/main/java/ch/epfl/sweng/studdybuddy/tools/Consumer.java
+++ b/app/src/main/java/ch/epfl/sweng/studdybuddy/tools/Consumer.java
@@ -1,4 +1,4 @@
-package ch.epfl.sweng.studdybuddy.util;
+package ch.epfl.sweng.studdybuddy.tools;
 
 public interface Consumer<T> {
     void accept(T t);

--- a/app/src/main/java/ch/epfl/sweng/studdybuddy/tools/CourseAdapter.java
+++ b/app/src/main/java/ch/epfl/sweng/studdybuddy/tools/CourseAdapter.java
@@ -1,4 +1,4 @@
-package ch.epfl.sweng.studdybuddy.util;
+package ch.epfl.sweng.studdybuddy.tools;
 
 import java.util.List;
 

--- a/app/src/main/java/ch/epfl/sweng/studdybuddy/tools/GroupsRecyclerAdapter.java
+++ b/app/src/main/java/ch/epfl/sweng/studdybuddy/tools/GroupsRecyclerAdapter.java
@@ -1,4 +1,4 @@
-package ch.epfl.sweng.studdybuddy.util;
+package ch.epfl.sweng.studdybuddy.tools;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
@@ -20,7 +20,6 @@ import ch.epfl.sweng.studdybuddy.Fragments.FeedFragment;
 import ch.epfl.sweng.studdybuddy.R;
 import ch.epfl.sweng.studdybuddy.activities.GroupActivity;
 import ch.epfl.sweng.studdybuddy.activities.GroupInfoActivity;
-import ch.epfl.sweng.studdybuddy.activities.GroupsActivity;
 import ch.epfl.sweng.studdybuddy.core.Group;
 import ch.epfl.sweng.studdybuddy.core.Pair;
 import ch.epfl.sweng.studdybuddy.firebase.FirebaseReference;
@@ -28,6 +27,9 @@ import ch.epfl.sweng.studdybuddy.firebase.MetaGroup;
 import ch.epfl.sweng.studdybuddy.firebase.ReferenceWrapper;
 import ch.epfl.sweng.studdybuddy.services.calendar.Availability;
 import ch.epfl.sweng.studdybuddy.services.calendar.ConnectedAvailability;
+import ch.epfl.sweng.studdybuddy.util.FeedFilter;
+import ch.epfl.sweng.studdybuddy.util.Helper;
+import ch.epfl.sweng.studdybuddy.util.Messages;
 
 public class GroupsRecyclerAdapter extends RecyclerView.Adapter<GroupsRecyclerAdapter.MyViewHolder> implements Filterable
 {

--- a/app/src/main/java/ch/epfl/sweng/studdybuddy/tools/Holder.java
+++ b/app/src/main/java/ch/epfl/sweng/studdybuddy/tools/Holder.java
@@ -1,4 +1,4 @@
-package ch.epfl.sweng.studdybuddy.util;
+package ch.epfl.sweng.studdybuddy.tools;
 
 import android.support.annotation.IdRes;
 import android.support.v7.widget.RecyclerView;

--- a/app/src/main/java/ch/epfl/sweng/studdybuddy/tools/ParticipantAdapter.java
+++ b/app/src/main/java/ch/epfl/sweng/studdybuddy/tools/ParticipantAdapter.java
@@ -1,4 +1,4 @@
-package ch.epfl.sweng.studdybuddy.util;
+package ch.epfl.sweng.studdybuddy.tools;
 
 import java.util.List;
 

--- a/app/src/main/java/ch/epfl/sweng/studdybuddy/tools/RecyclerAdapterAdapter.java
+++ b/app/src/main/java/ch/epfl/sweng/studdybuddy/tools/RecyclerAdapterAdapter.java
@@ -1,4 +1,4 @@
-package ch.epfl.sweng.studdybuddy.util;
+package ch.epfl.sweng.studdybuddy.tools;
 
 import android.support.v7.widget.RecyclerView;
 

--- a/app/src/main/java/ch/epfl/sweng/studdybuddy/util/FeedFilter.java
+++ b/app/src/main/java/ch/epfl/sweng/studdybuddy/util/FeedFilter.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import ch.epfl.sweng.studdybuddy.core.Group;
+import ch.epfl.sweng.studdybuddy.tools.GroupsRecyclerAdapter;
 
 public class FeedFilter extends Filter {
     GroupsRecyclerAdapter adapter;

--- a/app/src/test/java/ch/epfl/sweng/studdybuddy/FeedFilterTest.java
+++ b/app/src/test/java/ch/epfl/sweng/studdybuddy/FeedFilterTest.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 import ch.epfl.sweng.studdybuddy.core.Group;
 import ch.epfl.sweng.studdybuddy.util.FeedFilter;
-import ch.epfl.sweng.studdybuddy.util.GroupsRecyclerAdapter;
+import ch.epfl.sweng.studdybuddy.tools.GroupsRecyclerAdapter;
 
 import static ch.epfl.sweng.studdybuddy.util.CoreFactory.groups2;
 import static junit.framework.TestCase.assertEquals;

--- a/app/src/test/java/ch/epfl/sweng/studdybuddy/FirebaseReferenceTest.java
+++ b/app/src/test/java/ch/epfl/sweng/studdybuddy/FirebaseReferenceTest.java
@@ -15,7 +15,7 @@ import java.util.UUID;
 import ch.epfl.sweng.studdybuddy.core.Course;
 import ch.epfl.sweng.studdybuddy.core.Group;
 import ch.epfl.sweng.studdybuddy.firebase.FirebaseReference;
-import ch.epfl.sweng.studdybuddy.util.Consumer;
+import ch.epfl.sweng.studdybuddy.tools.Consumer;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;

--- a/app/src/test/java/ch/epfl/sweng/studdybuddy/HolderTest.java
+++ b/app/src/test/java/ch/epfl/sweng/studdybuddy/HolderTest.java
@@ -6,7 +6,7 @@ import android.widget.TextView;
 import org.junit.Before;
 import org.junit.Test;
 
-import ch.epfl.sweng.studdybuddy.util.Holder;
+import ch.epfl.sweng.studdybuddy.tools.Holder;
 
 import static junit.framework.TestCase.assertEquals;
 import static org.mockito.Mockito.mock;

--- a/app/src/test/java/ch/epfl/sweng/studdybuddy/ListenerFactoryTest.java
+++ b/app/src/test/java/ch/epfl/sweng/studdybuddy/ListenerFactoryTest.java
@@ -3,9 +3,9 @@ package ch.epfl.sweng.studdybuddy;
 import org.junit.Test;
 
 import ch.epfl.sweng.studdybuddy.util.FeedFilter;
-import ch.epfl.sweng.studdybuddy.util.GroupsRecyclerAdapter;
+import ch.epfl.sweng.studdybuddy.tools.GroupsRecyclerAdapter;
 
-import static ch.epfl.sweng.studdybuddy.util.AdapterConsumer.searchListener;
+import static ch.epfl.sweng.studdybuddy.tools.AdapterConsumer.searchListener;
 import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/app/src/test/java/ch/epfl/sweng/studdybuddy/ParticipantAdapterTest.java
+++ b/app/src/test/java/ch/epfl/sweng/studdybuddy/ParticipantAdapterTest.java
@@ -7,8 +7,8 @@ import java.util.Arrays;
 import java.util.List;
 
 import ch.epfl.sweng.studdybuddy.core.User;
-import ch.epfl.sweng.studdybuddy.util.Holder;
-import ch.epfl.sweng.studdybuddy.util.ParticipantAdapter;
+import ch.epfl.sweng.studdybuddy.tools.Holder;
+import ch.epfl.sweng.studdybuddy.tools.ParticipantAdapter;
 
 import static junit.framework.TestCase.assertTrue;
 import static org.mockito.Mockito.mock;


### PR DESCRIPTION
Fixed the bug that made the app crash when a group was deleted (by removing the adapter before the deletion).

Also broke down the util package into another package 'tools' which should contain Adapters, Consumers, Holders, ...