### PR TITLE
Chat bug

### DIFF
--- a/app/src/main/java/ch/epfl/sweng/studdybuddy/activities/ChatActivity.java
+++ b/app/src/main/java/ch/epfl/sweng/studdybuddy/activities/ChatActivity.java
@@ -53,10 +53,12 @@ public class ChatActivity extends AppCompatActivity{
             @Override
             public void onClick(View view) {
                 EditText input = (EditText)findViewById(R.id.input);
-                ref.select(Messages.FirebaseNode.CHAT).select(groupID).push(new ChatMessage(input.getText().toString(),
-                        FirebaseAuth.getInstance().getCurrentUser().getDisplayName()));
+                if(input.getText().toString().trim().length() > 0) {
+                    ref.select(Messages.FirebaseNode.CHAT).select(groupID).push(new ChatMessage(input.getText().toString(),
+                            FirebaseAuth.getInstance().getCurrentUser().getDisplayName()));
 
-                input.setText("");
+                    input.setText("");
+                }
             }
         };
     }


### PR DESCRIPTION
Fix bug where you can resend last sent message by clicking the FAB with an empty text, which also caused other undesired behaviors. It is fixed when sending messages from the same account on two devices as well