### PR TITLE
[Feature Branch] Friends backend

### DIFF
--- a/app/src/main/java/ch/epfl/sweng/studdybuddy/core/Buddy.java
+++ b/app/src/main/java/ch/epfl/sweng/studdybuddy/core/Buddy.java
@@ -1,0 +1,56 @@
+package ch.epfl.sweng.studdybuddy.core;
+
+import java.util.Date;
+
+import ch.epfl.sweng.studdybuddy.util.Helper;
+
+public final class Buddy {
+    public String getAlice() {
+        return alice;
+    }
+
+    public void setAlice(String alice) {
+        this.alice = alice;
+    }
+
+    public String getBob() {
+        return bob;
+    }
+
+    public void setBob(String bob) {
+        this.bob = bob;
+    }
+
+    public Long getCreationDate() {
+        return creationDate;
+    }
+
+    public void setCreationDate(Long creationDate) {
+        this.creationDate = creationDate;
+    }
+
+    private String alice;
+    private String bob;
+    private Long creationDate;
+    public Buddy(String alice, String bob) {
+        creationDate = new Date().getTime();
+        this.alice = alice;
+        this.bob = bob;
+    }
+
+    //Returns null if not buddy, because no Optionnal for Java<8
+    public String buddyOf(String uid) {
+        String buddy = null;
+        if(alice.equals(uid)) {
+            buddy = bob;
+        }
+        else if(bob.equals(uid)) {
+            buddy = alice;
+        }
+        return buddy;
+    }
+
+    public String hash() {
+        return Helper.hashCode(new Pair(alice, bob));
+    }
+}

--- a/app/src/main/java/ch/epfl/sweng/studdybuddy/core/Buddy.java
+++ b/app/src/main/java/ch/epfl/sweng/studdybuddy/core/Buddy.java
@@ -51,6 +51,6 @@ public final class Buddy {
     }
 
     public String hash() {
-        return Helper.hashCode(new Pair(alice, bob));
+        return Integer.toHexString(alice.hashCode() ^ bob.hashCode());
     }
 }

--- a/app/src/main/java/ch/epfl/sweng/studdybuddy/firebase/MetaGroup.java
+++ b/app/src/main/java/ch/epfl/sweng/studdybuddy/firebase/MetaGroup.java
@@ -1,5 +1,7 @@
 package ch.epfl.sweng.studdybuddy.firebase;
 
+import android.support.annotation.Nullable;
+
 import com.google.firebase.database.ValueEventListener;
 
 import java.util.ArrayList;
@@ -7,6 +9,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
+import ch.epfl.sweng.studdybuddy.core.Buddy;
 import ch.epfl.sweng.studdybuddy.core.Group;
 import ch.epfl.sweng.studdybuddy.core.Pair;
 import ch.epfl.sweng.studdybuddy.core.User;
@@ -136,5 +139,4 @@ public class MetaGroup extends Metabase{
         Pair pair = new Pair(creatorId,g.getGroupID().toString());
         db.select(Messages.FirebaseNode.USERGROUP).select(Helper.hashCode(pair)).setVal(pair);
     }
-
 }

--- a/app/src/main/java/ch/epfl/sweng/studdybuddy/firebase/Metabase.java
+++ b/app/src/main/java/ch/epfl/sweng/studdybuddy/firebase/Metabase.java
@@ -1,10 +1,14 @@
 package ch.epfl.sweng.studdybuddy.firebase;
 
+import android.support.annotation.Nullable;
+
 import com.google.firebase.database.ValueEventListener;
 
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 
+import ch.epfl.sweng.studdybuddy.core.Buddy;
 import ch.epfl.sweng.studdybuddy.core.ID;
 import ch.epfl.sweng.studdybuddy.core.User;
 import ch.epfl.sweng.studdybuddy.tools.AdapterAdapter;
@@ -55,4 +59,25 @@ abstract public class Metabase {
 
     public void clearListeners() { this.ads.clear(); }
 
+    //Will override old friendship but will not create doublon
+    public void befriend(String uid, String friend) {
+        Buddy buddy = new Buddy(uid, friend);
+        db.select(Messages.FirebaseNode.BUDDIES).select(buddy.hash()).setVal(buddy);
+    }
+
+    public ValueEventListener getBuddies(String uid, List<User> users) {
+        return db.select(Messages.FirebaseNode.BUDDIES).getAll(Buddy.class, new Consumer<List<Buddy>>() {
+            @Override
+            public void accept(@Nullable List<Buddy> buddies) {
+                List<String> buddiesIDs = new ArrayList<>();
+                for(Buddy buddy: buddies) {
+                    String bob = buddy.buddyOf(uid);
+                    if(bob != null) {
+                        buddiesIDs.add(bob);
+                    }
+                }
+                getUsersfromIds(buddiesIDs, users);
+            }
+        });
+    }
 }

--- a/app/src/main/java/ch/epfl/sweng/studdybuddy/util/Messages.java
+++ b/app/src/main/java/ch/epfl/sweng/studdybuddy/util/Messages.java
@@ -33,6 +33,6 @@ public class Messages {
         public static final String USERCOURSE = "userCourse";
         public static final String CHAT = "chat";
         public static final String USERS = "users";
-
+        public static final String BUDDIES = "buddies";
     }
 }

--- a/app/src/test/java/ch/epfl/sweng/studdybuddy/BuddyTest.java
+++ b/app/src/test/java/ch/epfl/sweng/studdybuddy/BuddyTest.java
@@ -1,0 +1,39 @@
+package ch.epfl.sweng.studdybuddy;
+
+import org.junit.Test;
+
+import ch.epfl.sweng.studdybuddy.core.Buddy;
+import ch.epfl.sweng.studdybuddy.core.Pair;
+import ch.epfl.sweng.studdybuddy.util.Helper;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class BuddyTest {
+    @Test
+    public void testSettersGetters() {
+        Buddy b = new Buddy("alice", "bob");
+        b.setAlice("bob");
+        b.setBob("alice");
+        b.setCreationDate((long)0);
+        assertEquals("alice", b.getBob());
+        assertEquals("bob", b.getAlice());
+        assertEquals(new Long(0), b.getCreationDate());
+    }
+
+    @Test
+    public void testBuddyOf() {
+        Buddy b = new Buddy("alice", "bob");
+        assertEquals("bob", b.buddyOf("alice"));
+        assertEquals("alice", b.buddyOf("bob"));
+        assertNull(b.buddyOf("eve"));
+    }
+    @Test
+    public void testHash() {
+        Buddy b = new Buddy("alice", "bob");
+        Buddy b2 = new Buddy("bob", "alice");
+        assertEquals(Integer.toHexString("alice".hashCode() ^ "bob".hashCode()), b.hash());
+        assertEquals(b.hash(), b2.hash());
+    }
+}

--- a/app/src/test/java/ch/epfl/sweng/studdybuddy/MetabaseTest.java
+++ b/app/src/test/java/ch/epfl/sweng/studdybuddy/MetabaseTest.java
@@ -10,15 +10,20 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import ch.epfl.sweng.studdybuddy.core.Buddy;
 import ch.epfl.sweng.studdybuddy.core.Pair;
 import ch.epfl.sweng.studdybuddy.core.User;
 import ch.epfl.sweng.studdybuddy.firebase.FirebaseReference;
 import ch.epfl.sweng.studdybuddy.firebase.MetaGroup;
 import ch.epfl.sweng.studdybuddy.tools.Consumer;
+import ch.epfl.sweng.studdybuddy.util.Messages;
 
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class MetabaseTest {
@@ -63,5 +68,15 @@ public class MetabaseTest {
                 assertTrue(user.getName().equals("Tintin")) ;
             }
         }).onDataChange(ds);
+    }
+
+    @Test
+    public void testBefriend() {
+        when(testref.child(anyString())).thenReturn(testref);
+        Buddy b = new Buddy("alice", "bob");
+        mb.befriend("alice", "bob");
+        verify(testref, times(1)).child(Messages.FirebaseNode.BUDDIES);
+        verify(testref, times(1)).child(b.hash());
+        verify(testref, times(1)).setValue(any(Buddy.class));
     }
 }


### PR DESCRIPTION
#31 
Notes:
```Buddy``` class is Database friendly and is basically a ```Pair``` with a creation date.
The method ```buddyOf``` returns a ```Nullable``` because Java 8 Optionnal's are not available in this project.
Because the hash function used is symmetric we can just push the database and be confident that there will be no doublons, we might override a friendship(change the date), but this is fine.

The reason why the hash function should be symmetric is that we would like arbitrary constant access to a particular location in the buddies table.